### PR TITLE
fix: Allow non-logged-in users to send messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -414,7 +414,7 @@ async function handleSendMessage() {
     }
 
     const userMessageId = Date.now() + '-' + Math.random().toString(36).substring(2, 9);
-    const userMessage = { role: 'user', parts: messageParts, id: userMessageId, userId: currentUser.uid };
+    const userMessage = { role: 'user', parts: messageParts, id: userMessageId, userId: currentUser ? currentUser.uid : null };
 
     // For synced chats, don't display the message immediately. Let the snapshot listener do it.
     // For local chats, display it right away.


### PR DESCRIPTION
Previously, the application would throw a TypeError when a non-logged-in user tried to send a message. This was because the code was trying to access `currentUser.uid` when `currentUser` was null.

This commit fixes the issue by adding a check to ensure that `currentUser.uid` is only accessed if `currentUser` exists. If `currentUser` is null, `userId` is set to `null`.